### PR TITLE
Update Better Function practices.ipynb

### DIFF
--- a/Python3/Better Function practices.ipynb
+++ b/Python3/Better Function practices.ipynb
@@ -45,6 +45,7 @@
    "outputs": [],
    "source": [
     "from numpy import sqrt"
+    "from numpy.ma import mean, std"
    ]
   },
   {


### PR DESCRIPTION
To import function as mean and Std, you have to import using "from NumPy.ma import mean, std". Using the latest version of pycharm, you can only import the function using the NumPy as a pointer.